### PR TITLE
Fix Vercel deployment

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,10 +16,13 @@ app.secret_key = 'consolidador_excel_2024'
 app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16MB max file size
 
 # Configurações
-UPLOAD_FOLDER = 'uploads'
+UPLOAD_FOLDER = os.environ.get(
+    'UPLOAD_FOLDER', os.path.join(tempfile.gettempdir(), 'uploads')
+)
 ALLOWED_EXTENSIONS = {'xls', 'xlsx'}
 
-# Criar pasta de uploads se não existir
+# Criar pasta de uploads se não existir (usado /tmp por padrão em ambientes
+# serverless)
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
 def allowed_file(filename):


### PR DESCRIPTION
## Summary
- store uploads inside `/tmp` when deploying on Vercel

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686cee7386d4832daef15287e1aa6dc8